### PR TITLE
Added ability to define state/obs rep from gym.make

### DIFF
--- a/gym_gridverse/gym.py
+++ b/gym_gridverse/gym.py
@@ -26,6 +26,14 @@ def outer_space_to_gym_space(space: Dict[str, np.ndarray]) -> gym.spaces.Space:
 
 
 class GymEnvironment(gym.Env):
+    """ OpenAI Gym environment interface for GridVerse environment
+
+    Args:
+        constructor: gym_gridverse.OuterEnv constructor used to construct environment
+        state_rep_override: Optional override of OuterEnv state representation (Defaults to None, no change).
+        obs_rep_override: Optional override of OuterEnv observation representation (Defaults to None, no change).
+
+    """
     metadata = {
         'render.modes': ['human', 'human_state', 'human_observation'],
         'video.frames_per_second': 50,
@@ -33,24 +41,30 @@ class GymEnvironment(gym.Env):
 
     # NOTE accepting an environment instance as input is a bad idea because it
     # would need to be instantiated during gym registration
-    def __init__(self, constructor: Callable[[], OuterEnv]):
+    def __init__(self, constructor: Callable[[], OuterEnv],
+                 state_rep_override: [str, None] = None,
+                 obs_rep_override: [str, None] = None):
         super().__init__()
         self.outer_env = constructor()
-
-        self.state_space = (
-            outer_space_to_gym_space(self.outer_env.state_rep.space)
-            if self.outer_env.state_rep is not None
-            else None
-        )
+        if state_rep_override is not None:
+            self.set_state_representation(state_rep_override)
+        else:
+            self.state_space = (
+                outer_space_to_gym_space(self.outer_env.state_rep.space)
+                if self.outer_env.state_rep is not None
+                else None
+            )
+        if obs_rep_override is not None:
+            self.set_observation_representation(obs_rep_override)
+        else:
+            self.observation_space = (
+                outer_space_to_gym_space(self.outer_env.observation_rep.space)
+                if self.outer_env.observation_rep is not None
+                else None
+            )
         self.action_space = gym.spaces.Discrete(
             self.outer_env.action_space.num_actions
         )
-        self.observation_space = (
-            outer_space_to_gym_space(self.outer_env.observation_rep.space)
-            if self.outer_env.observation_rep is not None
-            else None
-        )
-
         # self._state_viewer: Optional[GridVerseViewer] = None
         # self._observation_viewer: Optional[GridVerseViewer] = None
         self._state_viewer = None

--- a/tests/gym/test_gym.py
+++ b/tests/gym/test_gym.py
@@ -27,8 +27,28 @@ import pytest
         'GridVerse-KeyDoor-16x16-v0',
     ],
 )
-def test_gym_registration(env_id: str):
-    gym.make(env_id)
+@pytest.mark.parametrize(
+    'obs_rep_override',
+    [
+        None,
+        'default',
+        'no_overlap'
+    ]
+)
+@pytest.mark.parametrize(
+    'state_rep_override',
+    [
+        None,
+        'default',
+        'no_overlap'
+    ]
+)
+def test_gym_registration(env_id: str, obs_rep_override: [str, None], state_rep_override: [str, None]):
+    e0 = gym.make(env_id)
+    e = gym.make(env_id, obs_rep_override=obs_rep_override, state_rep_override=state_rep_override)
+    assert state_rep_override is None or e.state_space is not None
+    if obs_rep_override not in (None, 'default'): e0.set_observation_representation(obs_rep_override)
+    np.testing.assert_equal(e.observation_space, e0.observation_space)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
1) Changed GymEnvironment constructor to take "obs_rep_override" and "state_rep_override" arguments. This way, it's possible to pass representation strings (i.e., 'default', 'no_overlap') via gym.make(). Default behavior is unchanged ('default' obs rep, None state rep)

2) Updated test_gym_registration with cases of override